### PR TITLE
Make CI jobs triggered by a push only work on main and alpha branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+      - alpha
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Adapted from [here](https://github.com/orgs/community/discussions/26276)